### PR TITLE
Use full path for tools normally in /sbin

### DIFF
--- a/cleanup_image
+++ b/cleanup_image
@@ -21,4 +21,4 @@ echo "--> Cleaning up image file..."
 $SCRIPTSDIR/09_cleanup.sh
 
 echo "--> Compacting image file..."
-fstrim -v "$INSTALLDIR"
+/sbin/fstrim -v "$INSTALLDIR"

--- a/prepare_image
+++ b/prepare_image
@@ -46,10 +46,10 @@ echo "-> Preparing instalation of ${DIST} template..."
 if [ -f "${IMG}" ]; then
     echo "-> Image file already exists, assuming *update*..."
     if [ "0$TEMPLATE_ROOT_WITH_PARTITIONS" -eq 1 ]; then
-        IMG_LOOP=$(losetup -P -f --show "$IMG")
+        IMG_LOOP=$(/sbin/losetup -P -f --show "$IMG")
         IMG_DEV=${IMG_LOOP}p3
     else
-        IMG_LOOP=$(losetup -f --show "$IMG")
+        IMG_LOOP=$(/sbin/losetup -f --show "$IMG")
         IMG_DEV=${IMG_LOOP}
     fi
 else
@@ -68,10 +68,10 @@ size=2MiB, type=21686148-6449-6E6F-744E-656564454649, uuid=1e6c9db4-1e91-46c4-84
 type=0FC63DAF-8483-4772-8E79-3D69D8477DE4, uuid=693244e6-3e07-47bf-ad79-acade4293fe7, name="Root filesystem"
 EOF
 
-        IMG_LOOP=$(losetup -P -f --show "$IMG")
+        IMG_LOOP=$(/sbin/losetup -P -f --show "$IMG")
         IMG_DEV=${IMG_LOOP}p3
     else
-        IMG_LOOP=$(losetup -f --show "$IMG")
+        IMG_LOOP=$(/sbin/losetup -f --show "$IMG")
         IMG_DEV=${IMG_LOOP}
     fi
 
@@ -96,6 +96,6 @@ trap - EXIT
 
 echo "-> Unmounting prepared_image..."
 umount_kill "$(readlink -m ${INSTALLDIR})" || true
-losetup -d ${IMG_LOOP}
+/sbin/losetup -d ${IMG_LOOP}
 
 exit ${RETCODE}

--- a/qubeize_image
+++ b/qubeize_image
@@ -50,7 +50,7 @@ function cleanup() {
     trap - ERR
     trap
     umount_kill "$PWD/mnt" || true
-    losetup -d ${IMG_LOOP}
+    /sbin/losetup -d ${IMG_LOOP}
     exit $errval
 }
 trap cleanup ERR
@@ -72,10 +72,10 @@ fi
 echo "--> Mounting $IMG"
 mkdir -p mnt
 if [ "0$TEMPLATE_ROOT_WITH_PARTITIONS" -eq 1 ]; then
-    IMG_LOOP=$(losetup -P -f --show "$IMG")
+    IMG_LOOP=$(/sbin/losetup -P -f --show "$IMG")
     IMG_DEV=${IMG_LOOP}p3
 else
-    IMG_LOOP=$(losetup -f --show "$IMG")
+    IMG_LOOP=$(/sbin/losetup -f --show "$IMG")
     IMG_DEV=${IMG_LOOP}
 fi
 mount "$IMG_DEV" mnt || exit 1
@@ -123,7 +123,7 @@ ls -als $IMG
 # ------------------------------------------------------------------------------
 echo "--> Unmounting $IMG"
 umount_kill "$PWD/mnt" || true
-losetup -d ${IMG_LOOP}
+/sbin/losetup -d ${IMG_LOOP}
 
 echo "Qubeized image stored at: $IMG"
 


### PR DESCRIPTION
Do not rely on Fedora-specific setting - having /sbin in PATH also for
normal user. This allows to build templates on Debian.