### PR TITLE
Sign/upload templates packages similar to other rpm packages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,9 @@ TEMPLATE_ENV_WHITELIST += \
 	CENTOS_MIRROR EPEL_MIRROR QUBES_MIRROR
 
 # Make sure names are < 32 characters, process aliases
-fix_up := $(shell TEMPLATE_NAME=$(TEMPLATE_NAME) ./builder_fix_filenames)
+fix_up := $(shell TEMPLATE_NAME=$(TEMPLATE_NAME) \
+		TEMPLATE_LABEL="$(TEMPLATE_LABEL)" \
+		./builder_fix_filenames)
 TEMPLATE_NAME := $(word 1,$(fix_up))
 
 export TEMPLATE_NAME

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,9 @@ export DISTRIBUTION
 VERSION := $(shell cat version)
 TIMESTAMP := $(shell date -u +%Y%m%d%H%M)
 
+.PHONY: help template-name prepare package rpms rootimg-build
+.PHONY: update-repo-templates-itl update-repo-templates-community
+
 help:
 	@echo "make rpms                  -- generate template rpm"
 	@echo "make update-repo-installer -- copy newly generated rpm to installer repo"

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ export TEMPLATE_SCRIPTS
 export DISTRIBUTION
 
 VERSION := $(shell cat version)
-TIMESTAMP := $(shell date -u +%Y%m%d%H%M)
+TEMPLATE_TIMESTAMP ?= $(shell date -u +%Y%m%d%H%M)
 
 .PHONY: help template-name prepare package rpms rootimg-build
 .PHONY: update-repo-templates-itl update-repo-templates-community
@@ -48,7 +48,7 @@ template-name:
 
 prepare:
 	@echo "Building template: $(TEMPLATE_NAME)"
-	@echo $(TIMESTAMP) > build_timestamp_$(TEMPLATE_NAME)
+	@echo $(TEMPLATE_TIMESTAMP) > build_timestamp_$(TEMPLATE_NAME)
 
 package:
 	./build_template_rpm $(TEMPLATE_NAME)

--- a/Makefile.builder
+++ b/Makefile.builder
@@ -1,0 +1,5 @@
+# pretend that normal package is built from this repo, to reuse update-repo-* 
+ifeq ($(PACKAGE_SET),vm)
+OUTPUT_DIR = rpm
+RPM_SPEC_FILES = templates.spec
+endif

--- a/functions-name.sh
+++ b/functions-name.sh
@@ -71,7 +71,7 @@ templateNameDist() {
     template_name="$(templateName)" && dist_name="${template_name}"
 
     # Automaticly correct name length if it's greater than 32 chars
-    dist_name="$(templateNameFixLength ${template_name})"
+    dist_name="$(templateNameFixLength ${dist_name})"
 
     # Remove and '+' characters from name since they are invalid for name
     dist_name="${dist_name//+/-}"
@@ -79,7 +79,7 @@ templateNameDist() {
 }
 
 templateName() {
-    local template_flavor=${1-${TEMPLATE_FLAVOR}}
+    local template_flavor=${1:-${TEMPLATE_FLAVOR}}
     retval=1 # Default is 1; mean no replace happened
 
     # Only apply options if $1 was not passed

--- a/prepare_image
+++ b/prepare_image
@@ -80,7 +80,7 @@ EOF
     fi
 
     echo "-> Creating filesystem..."
-    mkfs.ext4 -q -F "${IMG_DEV}" || exit 1
+    /sbin/mkfs.ext4 -q -F "${IMG_DEV}" || exit 1
 fi
 
 mount "${IMG_DEV}" "${INSTALLDIR}" || exit 1

--- a/templates.spec
+++ b/templates.spec
@@ -3,8 +3,9 @@
 # This includes the VM's root image, patched with all qubes rpms, etc
 #
 
-%{!?version: %define version %(cat version)}
-%{!?rel: %define rel %(cat build_timestamp_%{template_name})}
+%{!?template_name: %global template_name %{getenv:TEMPLATE_NAME}}
+%{!?version: %global version %(cat version)}
+%{!?rel: %global rel %(cat build_timestamp_%{template_name} || echo unavailable)}
 
 Name:		qubes-template-%{template_name}
 Version:	%{version}
@@ -17,6 +18,7 @@ Source:		.
 
 Requires:	xdg-utils
 Requires(post):	tar
+BuildArch:  noarch
 Provides:	qubes-template
 Obsoletes:  %{name} > %{version}-%{release}
 


### PR DESCRIPTION
Make template build process similar enough to other rpm packages, that signing
and uploading could be done by builder-rpm the same was as for other packages.
The most important change is that templates.spec can be parsed without special
--define options. Use environment variables where really needed. 
Also, allow using specific timestamp instead of the current one, to make
template version predictable.

QubesOS/qubes-issues#3935