### PR TITLE
create templatevm instead of rpm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,9 @@ prepare:
 package:
 	./build_template_rpm $(TEMPLATE_NAME)
 
+vm: prepare rootimg-build
+	./create_vm_from_qubeized_image.sh
+
 rpms: prepare rootimg-build package
 	./create_template_list.sh || :
 

--- a/create_vm_from_qubeized_image.sh
+++ b/create_vm_from_qubeized_image.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+IMG_DIR=qubeized_images/$TEMPLATE_NAME
+if [ ! -d $IMG_DIR ] ; then
+	echo "dir not found: $IMG_DIR"
+	exit 1
+fi
+IMG_FILE=$IMG_DIR/root.img
+if [ ! -e $IMG_FILE ] ; then
+	echo "file not found: $IMG_FILE"
+	exit 1
+fi
+
+# TODO env overrides
+TPL_VMNAME=$TEMPLATE_NAME-`date +%Y%m%d`
+TPL_LABEL=purple
+
+HAVE=`qvm-ls -O NAME | grep "$TPL_VMNAME"`
+TPL_SUFF=0
+TPL_OVMNAME=$TPL_VMNAME
+TPL_VMNAME=`
+( echo $TPL_VMNAME
+while echo "$HAVE" | grep "^$TPL_VMNAME$" &> /dev/null; do
+	let TPL_SUFF=$TPL_SUFF+1
+	TPL_VMNAME="$TPL_OVMNAME-$TPL_SUFF"
+	echo $TPL_VMNAME
+done ) | tail -1
+`
+#echo TPL_VMNAME: $TPL_VMNAME
+echo "--> Creating $TPL_VMNAME ..."
+qvm-create --label $TPL_LABEL --class TemplateVM $TPL_VMNAME || exit 1
+
+echo "--> Setting $TPL_VMNAME properties ..."
+# TODO proper shell escape protection
+cat tplspec.$TEMPLATE_NAME $IMG_DIR/template.cfg | 
+grep -E "^(prop|feat) [-a-z_]* [a-z0-9A-Z_()/.]*$" | 
+while read t k v ; do 
+	echo "SPEC '$t' '$k' '$v'" 
+	if [ "x$t" == "xprop" ] ; then
+	       qvm-prefs $TPL_VMNAME $k "$v"
+	elif [ "x$t" == "xfeat" ] ; then
+	       qvm-features $TPL_VMNAME $k "$v"
+	else
+		echo BAD TAG $t
+	fi
+done
+
+echo "--> Copying root.img to $TPL_VMNAME:root ..."
+qrexec-client-vm $TPL_VMNAME admin.vm.volume.Import+root < $IMG_FILE
+
+exit 0
+

--- a/tplspec.mirage-firewall
+++ b/tplspec.mirage-firewall
@@ -1,0 +1,9 @@
+prop virt_mode pv
+prop memory 42
+prop vcpus 1
+prop kernelopts (hd0)/boot/grub/menu.lst
+prop kernel pvgrub
+prop provides_network True
+feat no-default-kernelopts 1
+feat gui 
+feat qrexec 1

--- a/tplspec.mirage-ssh-agent
+++ b/tplspec.mirage-ssh-agent
@@ -1,0 +1,9 @@
+prop virt_mode pv
+prop memory 23
+prop maxmem 42
+prop vcpus 1
+prop kernelopts (hd0)/boot/grub/menu.lst
+prop kernel pvgrub
+feat no-default-kernelopts 1
+feat gui
+feat qrexec 1


### PR DESCRIPTION
this allows templatevm creation via admin api

adding the tplspec files to this pkg isnt ideal, but the alternatives are equally bad.
so far the actual flavor specific builder plugins dont have to care about how their output is going to be ued.
the tplspec files should also be added to rpm builds.